### PR TITLE
add our beginners' guide to about/more link list

### DIFF
--- a/app/views/about/_links.html.haml
+++ b/app/views/about/_links.html.haml
@@ -9,3 +9,4 @@
         %li= link_to t('auth.login'), new_user_session_path
       %li= link_to t('about.terms'), terms_path
       %li= link_to t('about.source_code'), 'https://github.com/tootsuite/mastodon'
+      %li= link_to "מדריך למצטרפים חדשים", 'https://github.com/Toootim/Resources/blob/master/info/welcome.md'


### PR DESCRIPTION
I think this should work. I hope it should work.
(I did learn Ruby/Rails once, I swear!)